### PR TITLE
Use Docker to make the process reproduceable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM java
+
+RUN mkdir -p /app && \
+  curl http://datao.net/sparql-generate-jena.jar > /app/sparql-generate-jena.jar
+
+WORKDIR /data
+
+COPY . .
+
+ENTRYPOINT ["./run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@ rm -Rf rdf
 mkdir rdf
 echo "Running... please wait! (3GB, and a lot of patience, are required :)"
 echo
-for i in *sg; do java -jar /app/sparql-generate-jena.jar -q $i > rdf/${i}.rdf& done
+for i in *sg; do java -jar /app/sparql-generate-jena.jar -q $i -l INFO > rdf/${i}.rdf& done
 wait
 echo "RDF files are now available at directory " $RDFDIR
 cd - > /dev/null

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 which java > /dev/null || echo "Install Java first"
 which java > /dev/null || exit
-if [ ! -f sparql-generate-jena.jar ]; then
-	#Download a patched version of SparqlGenerate. Sources are available on GitHub at: https://github.com/lolive/sparql-generate/tree/master
-        curl --silent http://datao.net/sparql-generate-jena.jar > /app/sparql-generate-jena.jar
-fi
+
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 RDFDIR=$DIR/rdf
 cd $DIR

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@ which java > /dev/null || echo "Install Java first"
 which java > /dev/null || exit
 if [ ! -f sparql-generate-jena.jar ]; then
 	#Download a patched version of SparqlGenerate. Sources are available on GitHub at: https://github.com/lolive/sparql-generate/tree/master
-        curl --silent http://datao.net/sparql-generate-jena.jar > ./sparql-generate-jena.jar
+        curl --silent http://datao.net/sparql-generate-jena.jar > /app/sparql-generate-jena.jar
 fi
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 RDFDIR=$DIR/rdf
@@ -12,7 +12,7 @@ rm -Rf rdf
 mkdir rdf
 echo "Running... please wait! (3GB, and a lot of patience, are required :)"
 echo
-for i in *sg; do java -jar sparql-generate-jena.jar -q $i > rdf/${i/.sg/.rdf}& done
+for i in *sg; do java -jar /app/sparql-generate-jena.jar -q $i > rdf/${i}.rdf& done
 wait
 echo "RDF files are now available at directory " $RDFDIR
 cd - > /dev/null


### PR DESCRIPTION
It was really hard to reproduce your process to generate the RDF. So I developed a really small and simple Dockerfile to be able to easily run your program in 2 steps (and make sure it runs the same for everyone, everytime, everywhere)

```
# Build the program
docker build -t openfoodfacts-rdf .

# Run it
docker run -it openfoodfacts-rdf .
```

But even if the file is running properly I am getting the following DEBUG issue (here in Allergens):

```
DEBUG [main] (FUN_JSONPath.java:134) - No evaluation of "{\"name\":{\"lv\":\"Auzas\",\"el\":\"Γλουτένη\",\"mt\":\"Glutina\",\"jp\":\"グルテン\",\"ee\":\"Nisu\",\"ga\":\"Glútan\",\"es\":\"Gluten\",\"sv\":\"Gluten\",\"cs\":\"Lepek\",\"de\":\"Gluten\",\"it\":\"Glutine\",\"lt\":\"Avižos\",\"sl\":\"Gluten\",\"ar\":\"غلوتين\",\"da\":\"Gluten\",\"nl\":\"Gluten\",\"hu\":\"Glutén\",\"et\":\"Gluteen\",\"ro\":\"Gluten\",\"ru\":\"Глютен\",\"pl\":\"Gluten\",\"fr\":\"Gluten\",\"sk\":\"Glutén\",\"th\":\"กลูเต็น\",\"fi\":\"Gluteeniton\",\"en\":\"Gluten\",\"zh\":\"麸质\",\"bg\":\"Глутен\"}}", "$.wikidata.en"
com.jayway.jsonpath.PathNotFoundException: Missing property in path $['wikidata']
    at com.jayway.jsonpath.internal.path.PathToken.handleObjectProperty(PathToken.java:72)
    at com.jayway.jsonpath.internal.path.PropertyPathToken.evaluate(PropertyPathToken.java:77)
    at com.jayway.jsonpath.internal.path.RootPathToken.evaluate(RootPathToken.java:62)
    at com.jayway.jsonpath.internal.path.CompiledPath.evaluate(CompiledPath.java:53)
    at com.jayway.jsonpath.internal.path.CompiledPath.evaluate(CompiledPath.java:61)
    at com.jayway.jsonpath.JsonPath.read(JsonPath.java:187)
```

But then we are getting proper statements:
```
<http://world-fr.openfoodfacts.org/allergen/en:molluscs>
        a           food:Allergen ;
        rdfs:label  "Mäkkýše"@sk , "軟体動物"@jp , "Moluscos"@pt , "Moluscos"@es , "Moliuskai"@lt , "Weekdieren"@nl , "Mollusques"@fr , "Moilisc"@ga , "Мекотели"@bg , "Blötdjur"@sv , "Bløddyr"@da , "Gliemji"@lv , "Μαλάκια"@el , "Mehkužci"@sl , "رخويات"@ar , "Molluschi"@it , "Měkkýši"@cs , "软体动物"@zh , "Molluscs"@en , "Molluski"@mt , "Puhatestűek"@hu , "Моллюск"@ro , "Weichtiere"@de , "Molluskid"@et , "Mięczaki"@pl , "Nilviäiset"@fi , "มอลลัสกา"@th ;
        owl:sameAs  <http://www.wikidata.org/entity/Q1275863> .
```


Is it normal? Is this the expected result?
I can maybe add a tag to the java call to not print those DEBUG in the RDF files


Note that this is my Java configuration:

```
openjdk version "1.8.0_111"
OpenJDK Runtime Environment (build 1.8.0_111-8u111-b14-2~bpo8+1-b14)
OpenJDK 64-Bit Server VM (build 25.111-b14, mixed mode)
```